### PR TITLE
Throwing Overloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ test-ios:
 test-swift:
 	swift test
 
-test-all: test-linux test-mac test-ios
+test-all: test-linux test-macos test-ios

--- a/Sources/Overture/Chain.swift
+++ b/Sources/Overture/Chain.swift
@@ -43,7 +43,7 @@ public func chain<A, B, C, D, E>(
   _ i: @escaping (D) -> E?
   )
   -> (A) -> E? {
-    
+
     return { (a: A) -> E? in
       f(a)
         .flatMap(g)
@@ -82,6 +82,98 @@ public func chain<A, B, C, D, E, F, G>(
 
     return { (a: A) -> G? in
       f(a)
+        .flatMap(g)
+        .flatMap(h)
+        .flatMap(i)
+        .flatMap(j)
+        .flatMap(k)
+    }
+}
+
+
+/// Forward composition of functions that return optionals and throw. Useful for chaining operations that may fail.
+///
+///     chain(String.init(validatingUTF8:), URL.init(string:))
+///     // (UnsafePointer<CChar>) -> URL?
+///
+/// - Parameters:
+///   - f: A function that takes a value in `A` and returns an optional value in `B`.
+///   - a: An argument in `A`.
+///   - g: A function that takes a value in `B` and returns an optional value in `C`.
+///   - a: An argument in `B`.
+/// - Returns: A new function that takes a value in `A` and returns an optional value in `C`.
+/// - Note: This function is commonly seen in operator form as `>=>`.
+public func chain<A, B, C>(
+  _ f: @escaping (A) throws -> B?,
+  _ g: @escaping (B) throws -> C?
+  )
+  -> (A) throws -> C? {
+
+    return { (a: A) throws -> C? in
+      try f(a).flatMap(g)
+    }
+}
+
+public func chain<A, B, C, D>(
+  _ f: @escaping (A) throws -> B?,
+  _ g: @escaping (B) throws -> C?,
+  _ h: @escaping (C) throws -> D?
+  )
+  -> (A) throws -> D? {
+
+    return { (a: A) throws -> D? in
+      try f(a)
+        .flatMap(g)
+        .flatMap(h)
+    }
+}
+
+public func chain<A, B, C, D, E>(
+  _ f: @escaping (A) throws -> B?,
+  _ g: @escaping (B) throws -> C?,
+  _ h: @escaping (C) throws -> D?,
+  _ i: @escaping (D) throws -> E?
+  )
+  -> (A) throws -> E? {
+
+    return { (a: A) throws -> E? in
+      try f(a)
+        .flatMap(g)
+        .flatMap(h)
+        .flatMap(i)
+    }
+}
+
+public func chain<A, B, C, D, E, F>(
+  _ f: @escaping (A) throws -> B?,
+  _ g: @escaping (B) throws -> C?,
+  _ h: @escaping (C) throws -> D?,
+  _ i: @escaping (D) throws -> E?,
+  _ j: @escaping (E) throws -> F?
+  )
+  -> (A) throws -> F? {
+
+    return { (a: A) throws -> F? in
+      try f(a)
+        .flatMap(g)
+        .flatMap(h)
+        .flatMap(i)
+        .flatMap(j)
+    }
+}
+
+public func chain<A, B, C, D, E, F, G>(
+  _ f: @escaping (A) throws -> B?,
+  _ g: @escaping (B) throws -> C?,
+  _ h: @escaping (C) throws -> D?,
+  _ i: @escaping (D) throws -> E?,
+  _ j: @escaping (E) throws -> F?,
+  _ k: @escaping (F) throws -> G?
+  )
+  -> (A) throws -> G? {
+
+    return { (a: A) throws -> G? in
+      try f(a)
         .flatMap(g)
         .flatMap(h)
         .flatMap(i)
@@ -167,6 +259,91 @@ public func chain<A, B, C, D, E, F, G>(
 
     return { (a: A) -> [G] in
       f(a)
+        .flatMap(g)
+        .flatMap(h)
+        .flatMap(i)
+        .flatMap(j)
+        .flatMap(k)
+    }
+}
+
+/// Forward composition of functions that return arrays and throw.
+///
+/// - Parameters:
+///   - f: A function that takes a value in `A` and returns an array of `B`s.
+///   - g: A function that takes a value in `B` and returns an array of `C`s.
+/// - Returns: A new function that takes a value in `A` and returns an array of `C`s.
+public func chain<A, B, C>(
+  _ f: @escaping (A) throws -> [B],
+  _ g: @escaping (B) throws -> [C]
+  )
+  -> (A) throws -> [C] {
+
+    return { (a: A) throws -> [C] in
+      try f(a).flatMap(g)
+    }
+}
+
+public func chain<A, B, C, D>(
+  _ f: @escaping (A) throws -> [B],
+  _ g: @escaping (B) throws -> [C],
+  _ h: @escaping (C) throws -> [D]
+  )
+  -> (A) throws -> [D] {
+
+    return { (a: A) throws -> [D] in
+      try f(a)
+        .flatMap(g)
+        .flatMap(h)
+    }
+}
+
+public func chain<A, B, C, D, E>(
+  _ f: @escaping (A) throws -> [B],
+  _ g: @escaping (B) throws -> [C],
+  _ h: @escaping (C) throws -> [D],
+  _ i: @escaping (D) throws -> [E]
+  )
+  -> (A) throws -> [E] {
+
+    return { (a: A) throws -> [E] in
+      try f(a)
+        .flatMap(g)
+        .flatMap(h)
+        .flatMap(i)
+    }
+}
+
+public func chain<A, B, C, D, E, F>(
+  _ f: @escaping (A) throws -> [B],
+  _ g: @escaping (B) throws -> [C],
+  _ h: @escaping (C) throws -> [D],
+  _ i: @escaping (D) throws -> [E],
+  _ j: @escaping (E) throws -> [F]
+  )
+  -> (A) throws -> [F] {
+
+    return { (a: A) throws -> [F] in
+      try f(a)
+        .flatMap(g)
+        .flatMap(h)
+        .flatMap(i)
+        .flatMap(j)
+    }
+}
+
+public func chain<A, B, C, D, E, F, G>(
+  _ f: @escaping (A) throws -> [B],
+  _ g: @escaping (B) throws -> [C],
+  _ h: @escaping (C) throws -> [D],
+  _ i: @escaping (D) throws -> [E],
+  _ j: @escaping (E) throws -> [F],
+  _ k: @escaping (F) throws -> [G]
+  )
+  -> (A) throws -> [G] {
+
+    return { (a: A) throws -> [G] in
+      try f(a)
         .flatMap(g)
         .flatMap(h)
         .flatMap(i)

--- a/Sources/Overture/Chain.swift
+++ b/Sources/Overture/Chain.swift
@@ -90,19 +90,6 @@ public func chain<A, B, C, D, E, F, G>(
     }
 }
 
-
-/// Forward composition of functions that return optionals and throw. Useful for chaining operations that may fail.
-///
-///     chain(String.init(validatingUTF8:), URL.init(string:))
-///     // (UnsafePointer<CChar>) -> URL?
-///
-/// - Parameters:
-///   - f: A function that takes a value in `A` and returns an optional value in `B`.
-///   - a: An argument in `A`.
-///   - g: A function that takes a value in `B` and returns an optional value in `C`.
-///   - a: An argument in `B`.
-/// - Returns: A new function that takes a value in `A` and returns an optional value in `C`.
-/// - Note: This function is commonly seen in operator form as `>=>`.
 public func chain<A, B, C>(
   _ f: @escaping (A) throws -> B?,
   _ g: @escaping (B) throws -> C?
@@ -267,12 +254,6 @@ public func chain<A, B, C, D, E, F, G>(
     }
 }
 
-/// Forward composition of functions that return arrays and throw.
-///
-/// - Parameters:
-///   - f: A function that takes a value in `A` and returns an array of `B`s.
-///   - g: A function that takes a value in `B` and returns an array of `C`s.
-/// - Returns: A new function that takes a value in `A` and returns an array of `C`s.
 public func chain<A, B, C>(
   _ f: @escaping (A) throws -> [B],
   _ g: @escaping (B) throws -> [C]

--- a/Sources/Overture/Compose.swift
+++ b/Sources/Overture/Compose.swift
@@ -72,3 +72,77 @@ public func compose<A, B, C, D, E, F, G>(
       f(g(h(i(j(k(a))))))
     }
 }
+
+/// Backward composition of throwing functions.
+///
+/// - Parameters:
+///   - f: A function that takes a value in `B` and returns a value in `C`.
+///   - b: An argument in `B`.
+///   - g: A function that takes a value in `A` and returns a value in `B`.
+///   - a: An argument in `A`.
+/// - Returns: A new function that takes a value in `A` and returns a value in `C`.
+/// - Note: This function is commonly seen in operator form as `<<<`.
+public func compose<A, B, C>(
+  _ f: @escaping (B) throws -> C,
+  _ g: @escaping (A) throws -> B
+  )
+  -> (A) throws -> C {
+
+    return { (a: A) throws -> C in
+      try f(g(a))
+    }
+}
+
+public func compose<A, B, C, D>(
+  _ f: @escaping (C) throws -> D,
+  _ g: @escaping (B) throws -> C,
+  _ h: @escaping (A) throws -> B
+  )
+  -> (A) throws -> D {
+
+    return { (a: A) throws -> D in
+      try f(g(h(a)))
+    }
+}
+
+public func compose<A, B, C, D, E>(
+  _ f: @escaping (D) throws -> E,
+  _ g: @escaping (C) throws -> D,
+  _ h: @escaping (B) throws -> C,
+  _ i: @escaping (A) throws -> B
+  )
+  -> (A) throws -> E {
+
+    return { (a: A) throws -> E in
+      try f(g(h(i(a))))
+    }
+}
+
+public func compose<A, B, C, D, E, F>(
+  _ f: @escaping (E) throws -> F,
+  _ g: @escaping (D) throws -> E,
+  _ h: @escaping (C) throws -> D,
+  _ i: @escaping (B) throws -> C,
+  _ j: @escaping (A) throws -> B
+  )
+  -> (A) throws -> F {
+
+    return { (a: A) throws -> F in
+      try f(g(h(i(j(a)))))
+    }
+}
+
+public func compose<A, B, C, D, E, F, G>(
+  _ f: @escaping (F) throws -> G,
+  _ g: @escaping (E) throws -> F,
+  _ h: @escaping (D) throws -> E,
+  _ i: @escaping (C) throws -> D,
+  _ j: @escaping (B) throws -> C,
+  _ k: @escaping (A) throws -> B
+  )
+  -> (A) throws -> G {
+
+    return { (a: A) throws -> G in
+      try f(g(h(i(j(k(a))))))
+    }
+}

--- a/Sources/Overture/Concat.swift
+++ b/Sources/Overture/Concat.swift
@@ -12,13 +12,31 @@ public func concat<A>(
   and fz: @escaping (_ a: A) -> A = { $0 }
   )
   -> (A) -> A {
-    
+
     return { (a: A) -> A in
       fz(fs.reduce(a) { a, f in f(a) })
     }
 }
 
-/// Forward, mutable value composition of functions that take and return the same type.
+/// Forward composition of throwing functions that take and return the same type.
+///
+/// - Parameters:
+///   - fs: Zero or more functions to apply in order.
+///   - fz: A final, optional, terminating function for trailing closure syntax.
+///   - a: The argument to the final function.
+/// - Returns: A new function that applies every function given as input in order.
+/// - Note: This function is commonly seen in operator form as `<>`.
+public func concat<A>(
+  _ fs: ((A) throws -> A)...,
+  and fz: @escaping (_ a: A) throws -> A = { $0 }
+  )
+  -> (A) throws -> A {
+
+    return { (a: A) throws -> A in
+      try fz(fs.reduce(a) { a, f in try f(a) })
+    }
+}
+
 ///
 /// - Parameters:
 ///   - fs: Zero or more functions to apply in order.
@@ -35,6 +53,27 @@ public func concat<A>(
     return { (a: inout A) -> Void in
       fs.forEach { f in f(&a) }
       fz(&a)
+    }
+}
+
+
+/// Forward, mutable value composition of throwing functions that take and return the same type.
+///
+/// - Parameters:
+///   - fs: Zero or more functions to apply in order.
+///   - fz: A final, optional, terminating function for trailing closure syntax.
+///   - a: The argument to the final function.
+/// - Returns: A new function that applies every function given as input in order.
+/// - Note: This function is commonly seen in operator form as `<>`.
+public func concat<A>(
+  _ fs: ((inout A) throws -> Void)...,
+  and fz: @escaping (_ a: inout A) throws -> Void = { _ in }
+  )
+  -> (inout A) throws -> Void {
+
+    return { (a: inout A) throws -> Void in
+      try fs.forEach { f in try f(&a) }
+      try fz(&a)
     }
 }
 
@@ -55,5 +94,25 @@ public func concat<A: AnyObject>(
     return { (a: A) -> Void in
       fs.forEach { f in f(a) }
       fz(a)
+    }
+}
+
+/// Forward, mutable reference composition of throwing functions that take and return the same type.
+///
+/// - Parameters:
+///   - fs: Zero or more functions to apply in order.
+///   - fz: A final, optional, terminating function for trailing closure syntax.
+///   - a: The argument to the final function.
+/// - Returns: A new function that applies every function given as input in order.
+/// - Note: This function is commonly seen in operator form as `<>`.
+public func concat<A: AnyObject>(
+  _ fs: ((A) throws -> Void)...,
+  and fz: @escaping (_ a: A) throws -> Void
+  )
+  -> (A) throws -> Void {
+
+    return { (a: A) throws -> Void in
+      try fs.forEach { f in try f(a) }
+      try fz(a)
     }
 }

--- a/Sources/Overture/Optional.swift
+++ b/Sources/Overture/Optional.swift
@@ -10,3 +10,15 @@ public func map<A, B>(
 
     return { $0.map(transform) }
 }
+
+/// Free `map` on optionals for throwing function composition.
+///
+/// - Parameter transform: A transform function.
+/// - Returns: An optional with its wrapped value transformed.
+public func map<A, B>(
+  _ transform: @escaping (A) throws -> B
+  )
+  -> (A?) throws -> B? {
+
+    return { try $0.map(transform) }
+}

--- a/Sources/Overture/Pipe.swift
+++ b/Sources/Overture/Pipe.swift
@@ -72,3 +72,77 @@ public func pipe<A, B, C, D, E, F, G>(
       k(j(i(h(g(f(a))))))
     }
 }
+
+/// Forward composition of functions.
+///
+/// - Parameters:
+///   - f: A function that takes a value in `A` and returns a value in `B`.
+///   - a: An argument in `A`.
+///   - g: A function that takes a value in `B` and returns a value in `C`.
+///   - b: An argument in `B`.
+/// - Returns: A new function that takes a value in `A` and returns a value in `C`.
+/// - Note: This function is commonly seen in operator form as `>>>`.
+public func pipe<A, B, C>(
+  _ f: @escaping (_ a: A) throws -> B,
+  _ g: @escaping (_ b: B) throws -> C
+  )
+  -> (A) throws -> C {
+
+    return { (a: A) throws -> C in
+      try g(f(a))
+    }
+}
+
+public func pipe<A, B, C, D>(
+  _ f: @escaping (A) throws -> B,
+  _ g: @escaping (B) throws -> C,
+  _ h: @escaping (C) throws -> D
+  )
+  -> (A) throws -> D {
+
+    return { (a: A) throws -> D in
+      try h(g(f(a)))
+    }
+}
+
+public func pipe<A, B, C, D, E>(
+  _ f: @escaping (A) throws -> B,
+  _ g: @escaping (B) throws -> C,
+  _ h: @escaping (C) throws -> D,
+  _ i: @escaping (D) throws -> E
+  )
+  -> (A) throws -> E {
+
+    return { (a: A) throws -> E in
+      try i(h(g(f(a))))
+    }
+}
+
+public func pipe<A, B, C, D, E, F>(
+  _ f: @escaping (A) throws -> B,
+  _ g: @escaping (B) throws -> C,
+  _ h: @escaping (C) throws -> D,
+  _ i: @escaping (D) throws -> E,
+  _ j: @escaping (E) throws -> F
+  )
+  -> (A) throws -> F {
+
+    return { (a: A) throws -> F in
+      try j(i(h(g(f(a)))))
+    }
+}
+
+public func pipe<A, B, C, D, E, F, G>(
+  _ f: @escaping (A) throws -> B,
+  _ g: @escaping (B) throws -> C,
+  _ h: @escaping (C) throws -> D,
+  _ i: @escaping (D) throws -> E,
+  _ j: @escaping (E) throws -> F,
+  _ k: @escaping (F) throws -> G
+  )
+  -> (A) throws -> G {
+
+    return { (a: A) throws -> G in
+      try k(j(i(h(g(f(a))))))
+    }
+}

--- a/Sources/Overture/Sequence.swift
+++ b/Sources/Overture/Sequence.swift
@@ -10,3 +10,15 @@ public func map<S: Sequence, A>(
 
     return { $0.map(transform) }
 }
+
+/// Free `map` on sequences for throwing function composition.
+///
+/// - Parameter transform: A transform function.
+/// - Returns: An array with each sequence element transformed.
+public func map<S: Sequence, A>(
+  _ transform: @escaping (S.Element) throws -> A
+  )
+  -> (S) throws -> [A] {
+
+    return { try $0.map(transform) }
+}

--- a/Sources/Overture/With.swift
+++ b/Sources/Overture/With.swift
@@ -8,8 +8,8 @@
 ///   - f: A function.
 /// - Returns: The result of `f` applied to `a`.
 /// - Note: This function is commonly seen in operator form as "pipe-forward", `|>`.
-public func with<A, B>(_ a: A, _ f: (A) -> B) -> B {
-  return f(a)
+public func with<A, B>(_ a: A, _ f: (A) throws -> B) rethrows -> B {
+  return try f(a)
 }
 
 /// Left-to-right, in-place function application.
@@ -18,8 +18,8 @@ public func with<A, B>(_ a: A, _ f: (A) -> B) -> B {
 ///   - a: A mutable value.
 ///   - f: An in-out function.
 /// - Note: This function is commonly seen in operator form as "pipe-forward", `|>`.
-public func with<A>(_ a: inout A, _ f: (inout A) -> Void) {
-  f(&a)
+public func with<A>(_ a: inout A, _ f: (inout A) throws -> Void) rethrows {
+  try f(&a)
 }
 
 /// Left-to-right, value-mutable function application.
@@ -29,9 +29,9 @@ public func with<A>(_ a: inout A, _ f: (inout A) -> Void) {
 ///   - f: An in-out function.
 /// - Returns: The result of `f` applied to `a`.
 /// - Note: This function is commonly seen in operator form as "pipe-forward", `|>`.
-public func with<A>(_ a: A, _ f: (inout A) -> Void) -> A {
+public func with<A>(_ a: A, _ f: (inout A) throws -> Void) rethrows -> A {
   var a = a
-  f(&a)
+  try f(&a)
   return a
 }
 
@@ -43,7 +43,7 @@ public func with<A>(_ a: A, _ f: (inout A) -> Void) -> A {
 /// - Returns: The result of `f` applied to `a`.
 /// - Note: This function is commonly seen in operator form as "pipe-forward", `|>`.
 @discardableResult
-public func with<A: AnyObject>(_ a: A, _ f: (A) -> Void) -> A {
-  f(a)
+public func with<A: AnyObject>(_ a: A, _ f: (A) throws -> Void) rethrows -> A {
+  try f(a)
   return a
 }

--- a/Sources/Overture/Zurry.swift
+++ b/Sources/Overture/Zurry.swift
@@ -3,6 +3,6 @@
 ///
 /// - Parameter function: A function taking zero arguments.
 /// - Returns: The return value.
-public func zurry<A>(_ function: @escaping () -> A) -> A {
-  return function()
+public func zurry<A>(_ function: @escaping () throws -> A) rethrows -> A {
+  return try function()
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -31,10 +31,15 @@ extension ChainTests {
 extension ComposeTests {
   static var allTests: [(String, (ComposeTests) -> () throws -> Void)] = [
     ("testCompose2", testCompose2),
+    ("testThrowingCompose2", testThrowingCompose2),
     ("testCompose3", testCompose3),
+    ("testThrowingCompose3", testThrowingCompose3),
     ("testCompose4", testCompose4),
+    ("testThrowingCompose4", testThrowingCompose4),
     ("testCompose5", testCompose5),
-    ("testCompose6", testCompose6)
+    ("testThrowingCompose5", testThrowingCompose5),
+    ("testCompose6", testCompose6),
+    ("testThrowingCompose6", testThrowingCompose6)
   ]
 }
 extension ConcatTests {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -45,7 +45,9 @@ extension ComposeTests {
 extension ConcatTests {
   static var allTests: [(String, (ConcatTests) -> () throws -> Void)] = [
     ("testConcat", testConcat),
-    ("testInoutConcat", testInoutConcat)
+    ("testThrowingConcat", testThrowingConcat),
+    ("testInoutConcat", testInoutConcat),
+    ("testThrowingInoutConcat", testThrowingInoutConcat)
   ]
 }
 extension CurryTests {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest
@@ -7,15 +7,25 @@ import XCTest
 extension ChainTests {
   static var allTests: [(String, (ChainTests) -> () throws -> Void)] = [
     ("testOptionalChain2", testOptionalChain2),
+    ("testThrowingOptionalChain2", testThrowingOptionalChain2),
     ("testOptionalChain3", testOptionalChain3),
+    ("testThrowingOptionalChain3", testThrowingOptionalChain3),
     ("testOptionalChain4", testOptionalChain4),
+    ("testThrowingOptionalChain4", testThrowingOptionalChain4),
     ("testOptionalChain5", testOptionalChain5),
+    ("testThrowingOptionalChain5", testThrowingOptionalChain5),
     ("testOptionalChain6", testOptionalChain6),
+    ("testThrowingOptionalChain6", testThrowingOptionalChain6),
     ("testArrayChain2", testArrayChain2),
+    ("testThrowingArrayChain2", testThrowingArrayChain2),
     ("testArrayChain3", testArrayChain3),
+    ("testThrowingArrayChain3", testThrowingArrayChain3),
     ("testArrayChain4", testArrayChain4),
+    ("testThrowingArrayChain4", testThrowingArrayChain4),
     ("testArrayChain5", testArrayChain5),
-    ("testArrayChain6", testArrayChain6)
+    ("testThrowingArrayChain5", testThrowingArrayChain5),
+    ("testArrayChain6", testArrayChain6),
+    ("testThrowingArrayChain6", testThrowingArrayChain6)
   ]
 }
 extension ComposeTests {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -57,10 +57,15 @@ extension CurryTests {
 extension PipeTests {
   static var allTests: [(String, (PipeTests) -> () throws -> Void)] = [
     ("testPipe2", testPipe2),
+    ("testThrowingPipe2", testThrowingPipe2),
     ("testPipe3", testPipe3),
+    ("testThrowingPipe3", testThrowingPipe3),
     ("testPipe4", testPipe4),
+    ("testThrowingPipe4", testThrowingPipe4),
     ("testPipe5", testPipe5),
-    ("testPipe6", testPipe6)
+    ("testThrowingPipe5", testThrowingPipe5),
+    ("testPipe6", testPipe6),
+    ("testThrowingPipe6", testThrowingPipe6)
   ]
 }
 extension WithTests {

--- a/Tests/OvertureTests/ChainTests.swift
+++ b/Tests/OvertureTests/ChainTests.swift
@@ -26,10 +26,34 @@ final class ChainTests: XCTestCase {
     XCTAssertNil(chain(fail, incr, incr)(2))
   }
 
+  func testThrowingOptionalChain3() {
+    XCTAssertEqual(.some(16), try chain(nonThrowing(incr), incr, square)(2))
+    XCTAssertNil(try chain(nonThrowing(incr), incr, fail)(2))
+    XCTAssertNil(try chain(nonThrowing(fail), incr, incr)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, square)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, fail)(2))
+    XCTAssertThrowsError(try chain(throwing(fail), incr, incr)(2))
+    XCTAssertThrowsError(try chain(incr, incr, throwing(square))(2))
+    XCTAssertThrowsError(try chain(incr, incr, throwing(fail))(2))
+    XCTAssertNil(try chain(fail, incr, throwing(incr))(2))
+  }
+
   func testOptionalChain4() {
     XCTAssertEqual(.some(25), chain(incr, incr, incr, square)(2))
     XCTAssertNil(chain(incr, incr, incr, fail)(2))
     XCTAssertNil(chain(fail, incr, incr, incr)(2))
+  }
+
+  func testThrowingOptionalChain4() {
+    XCTAssertEqual(.some(25), try chain(nonThrowing(incr), incr, incr, square)(2))
+    XCTAssertNil(try chain(nonThrowing(incr), incr, incr, fail)(2))
+    XCTAssertNil(try chain(nonThrowing(fail), incr, incr, incr)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, incr, square)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, incr, fail)(2))
+    XCTAssertThrowsError(try chain(throwing(fail), incr, incr, incr)(2))
+    XCTAssertThrowsError(try chain(incr, incr, incr, throwing(square))(2))
+    XCTAssertThrowsError(try chain(incr, incr, incr, throwing(fail))(2))
+    XCTAssertNil(try chain(fail, incr, incr, throwing(incr))(2))
   }
 
   func testOptionalChain5() {
@@ -38,10 +62,34 @@ final class ChainTests: XCTestCase {
     XCTAssertNil(chain(fail, incr, incr, incr, incr)(2))
   }
 
+  func testThrowingOptionalChain5() {
+    XCTAssertEqual(.some(36), try chain(nonThrowing(incr), incr, incr, incr, square)(2))
+    XCTAssertNil(try chain(nonThrowing(incr), incr, incr, incr, fail)(2))
+    XCTAssertNil(try chain(nonThrowing(fail), incr, incr, incr, incr)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, incr, incr, square)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, incr, incr, fail)(2))
+    XCTAssertThrowsError(try chain(throwing(fail), incr, incr, incr, incr)(2))
+    XCTAssertThrowsError(try chain(incr, incr, incr, incr, throwing(square))(2))
+    XCTAssertThrowsError(try chain(incr, incr, incr, incr, throwing(fail))(2))
+    XCTAssertNil(try chain(fail, incr, incr, incr, throwing(incr))(2))
+  }
+
   func testOptionalChain6() {
     XCTAssertEqual(.some(49), chain(incr, incr, incr, incr, incr, square)(2))
     XCTAssertNil(chain(incr, incr, incr, incr, incr, fail)(2))
     XCTAssertNil(chain(fail, incr, incr, incr, incr, incr)(2))
+  }
+
+  func testThrowingOptionalChain6() {
+    XCTAssertEqual(.some(49), try chain(nonThrowing(incr), incr, incr, incr, incr, square)(2))
+    XCTAssertNil(try chain(nonThrowing(incr), incr, incr, incr, incr, fail)(2))
+    XCTAssertNil(try chain(nonThrowing(fail), incr, incr, incr, incr, incr)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, incr, incr, incr, square)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), incr, incr, incr, incr, fail)(2))
+    XCTAssertThrowsError(try chain(throwing(fail), incr, incr, incr, incr, incr)(2))
+    XCTAssertThrowsError(try chain(incr, incr, incr, incr, incr, throwing(square))(2))
+    XCTAssertThrowsError(try chain(incr, incr, incr, incr, incr, throwing(fail))(2))
+    XCTAssertNil(try chain(fail, incr, incr, incr, incr, throwing(incr))(2))
   }
 
   func testArrayChain2() {
@@ -51,10 +99,30 @@ final class ChainTests: XCTestCase {
     XCTAssertEqual([], chain(zero, two)(1))
   }
 
+  func testThrowingArrayChain2() {
+    XCTAssertEqual([1, 1, 2, 2], try chain(nonThrowing(twoPlusOne), two)(1))
+    XCTAssertEqual([1, 2, 1, 2], try chain(two, nonThrowing(twoPlusOne))(1))
+    XCTAssertEqual([], try chain(nonThrowing(two), zero)(1))
+    XCTAssertEqual([], try chain(zero, nonThrowing(two))(1))
+    XCTAssertThrowsError(try chain(throwing(twoPlusOne), two)(1))
+    XCTAssertThrowsError(try chain(two, throwing(twoPlusOne))(1))
+    XCTAssertThrowsError(try chain(throwing(two), zero)(1))
+    XCTAssertEqual([], try chain(zero, throwing(two))(1))
+  }
+
   func testArrayChain3() {
     XCTAssertEqual(Array(repeatElement(1, count: 8)), chain(two, two, two)(1))
     XCTAssertEqual([], chain(two, two, zero)(1))
     XCTAssertEqual([], chain(zero, two, two)(1))
+  }
+
+  func testThrowingArrayChain3() {
+    XCTAssertEqual(Array(repeatElement(1, count: 8)), try chain(nonThrowing(two), two, two)(1))
+    XCTAssertEqual([], try chain(nonThrowing(two), two, zero)(1))
+    XCTAssertEqual([], try chain(zero, two, nonThrowing(two))(1))
+    XCTAssertThrowsError(try chain(throwing(two), two, two)(1))
+    XCTAssertThrowsError(try chain(throwing(two), two, zero)(1))
+    XCTAssertEqual([], try chain(zero, two, throwing(two))(1))
   }
 
   func testArrayChain4() {
@@ -63,16 +131,43 @@ final class ChainTests: XCTestCase {
     XCTAssertEqual([], chain(zero, two, two, two)(1))
   }
 
+  func testThrowingArrayChain4() {
+    XCTAssertEqual(Array(repeatElement(1, count: 16)), try chain(nonThrowing(two), two, two, two)(1))
+    XCTAssertEqual([], try chain(nonThrowing(two), two, two, zero)(1))
+    XCTAssertEqual([], try chain(zero, two, two, nonThrowing(two))(1))
+    XCTAssertThrowsError(try chain(throwing(two), two, two, two)(1))
+    XCTAssertThrowsError(try chain(throwing(two), two, two, zero)(1))
+    XCTAssertEqual([], try chain(zero, two, two, throwing(two))(1))
+  }
+
   func testArrayChain5() {
     XCTAssertEqual(Array(repeatElement(1, count: 32)), chain(two, two, two, two, two)(1))
     XCTAssertEqual([], chain(two, two, two, two, zero)(1))
     XCTAssertEqual([], chain(zero, two, two, two, two)(1))
   }
 
+  func testThrowingArrayChain5() {
+    XCTAssertEqual(Array(repeatElement(1, count: 32)), try chain(nonThrowing(two), two, two, two, two)(1))
+    XCTAssertEqual([], try chain(two, nonThrowing(two), two, two, zero)(1))
+    XCTAssertEqual([], try chain(zero, two, nonThrowing(two), two, nonThrowing(two))(1))
+    XCTAssertThrowsError(try chain(two, two, throwing(two), two, two)(1))
+    XCTAssertThrowsError(try chain(two, two, two, throwing(two), zero)(1))
+    XCTAssertEqual([], try chain(zero, two, two, two, throwing(two))(1))
+  }
+
   func testArrayChain6() {
     XCTAssertEqual(Array(repeatElement(1, count: 64)), chain(two, two, two, two, two, two)(1))
     XCTAssertEqual([], chain(two, two, two, two, two, zero)(1))
     XCTAssertEqual([], chain(zero, two, two, two, two, two)(1))
+  }
+
+  func testThrowingArrayChain6() {
+    XCTAssertEqual(Array(repeatElement(1, count: 64)), try chain(nonThrowing(two), two, two, two, two, two)(1))
+    XCTAssertEqual([], try chain(two, two, two, nonThrowing(two), two, zero)(1))
+    XCTAssertEqual([], try chain(zero, two, two, two, nonThrowing(two), two)(1))
+    XCTAssertThrowsError(try chain(throwing(two), two, two, two, two, two)(1))
+    XCTAssertThrowsError(try chain(two, two, two, throwing(two), two, zero)(1))
+    XCTAssertEqual([], try chain(zero, two, two, two, throwing(two), two)(1))
   }
 }
 

--- a/Tests/OvertureTests/ChainTests.swift
+++ b/Tests/OvertureTests/ChainTests.swift
@@ -8,6 +8,18 @@ final class ChainTests: XCTestCase {
     XCTAssertNil(chain(fail, incr)(2))
   }
 
+  func testThrowingOptionalChain2() {
+    XCTAssertEqual(.some(9), try chain(nonThrowing(incr), square)(2))
+    XCTAssertNil(try chain(nonThrowing(incr), fail)(2))
+    XCTAssertNil(try chain(nonThrowing(fail), incr)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), square)(2))
+    XCTAssertThrowsError(try chain(throwing(incr), fail)(2))
+    XCTAssertThrowsError(try chain(throwing(fail), incr)(2))
+    XCTAssertThrowsError(try chain(incr, throwing(square))(2))
+    XCTAssertThrowsError(try chain(incr, throwing(fail))(2))
+    XCTAssertNil(try chain(fail, throwing(incr))(2))
+  }
+
   func testOptionalChain3() {
     XCTAssertEqual(.some(16), chain(incr, incr, square)(2))
     XCTAssertNil(chain(incr, incr, fail)(2))
@@ -86,4 +98,13 @@ private func twoPlusOne(_ x: Int) -> [Int] {
 
 private func zero(_ x: Int) -> [Int] {
   return []
+}
+
+private struct ExpectedError: Error {}
+private func throwing<A, B>(_: (A) -> B) -> (A) throws -> B {
+    return { _ in throw ExpectedError() }
+}
+
+private func nonThrowing<A, B>(_ f: @escaping (A) -> B) -> (A) throws -> B {
+    return f
 }

--- a/Tests/OvertureTests/ComposeTests.swift
+++ b/Tests/OvertureTests/ComposeTests.swift
@@ -6,23 +6,57 @@ final class ComposeTests: XCTestCase {
     XCTAssertEqual("2", compose(String.init, incr)(1))
   }
 
+  func testThrowingCompose2() {
+    XCTAssertEqual("2", try compose(nonThrowing(String.init), incr)(1))
+    XCTAssertThrowsError(try compose(String.init, throwing(incr))(1))
+  }
+
   func testCompose3() {
     XCTAssertEqual("3", compose(String.init, incr, incr)(1))
+  }
+
+  func testThrowingCompose3() {
+    XCTAssertEqual("3", try compose(String.init, nonThrowing(incr), incr)(1))
+    XCTAssertThrowsError(try compose(String.init, incr, throwing(incr))(1))
   }
 
   func testCompose4() {
     XCTAssertEqual("4", compose(String.init, incr, incr, incr)(1))
   }
 
+  func testThrowingCompose4() {
+    XCTAssertEqual("4", try compose(String.init, incr, incr, nonThrowing(incr))(1))
+    XCTAssertThrowsError(try compose(throwing(String.init), incr, incr, incr)(1))
+  }
+
   func testCompose5() {
     XCTAssertEqual("5", compose(String.init, incr, incr, incr, incr)(1))
+  }
+
+  func testThrowingCompose5() {
+    XCTAssertEqual("5", try compose(String.init, incr, incr, nonThrowing(incr), incr)(1))
+    XCTAssertThrowsError(try compose(String.init, incr, throwing(incr), incr, incr)(1))
   }
 
   func testCompose6() {
     XCTAssertEqual("6", compose(String.init, incr, incr, incr, incr, incr)(1))
   }
+
+  func testThrowingCompose6() {
+    XCTAssertEqual("6", try compose(String.init, incr, incr, nonThrowing(incr), incr, incr)(1))
+    XCTAssertThrowsError(try compose(String.init, incr, incr, throwing(incr), incr, incr)(1))
+  }
 }
 
 private func incr(_ x: Int) -> Int {
   return x + 1
+}
+
+private struct ExpectedError: Error {}
+private func throwing<A, B>(_: (A) -> B) -> (A) throws -> B {
+    return { _ in throw ExpectedError() }
+}
+
+private func nonThrowing<A, B>(_ f: @escaping (A) -> B) -> (A) throws -> B {
+    return f
 }

--- a/Tests/OvertureTests/ConcatTests.swift
+++ b/Tests/OvertureTests/ConcatTests.swift
@@ -29,7 +29,7 @@ final class ConcatTests: XCTestCase {
     XCTAssertEqual(82, x)
 
     x = 1
-    concat(incr, incr, square, square) { $0 += 1 }(&x)
+    concat(incr, incr, square, square) { (y: inout Int) in y += 1 }(&x)
     XCTAssertEqual(82, x)
   }
 }

--- a/Tests/OvertureTests/ConcatTests.swift
+++ b/Tests/OvertureTests/ConcatTests.swift
@@ -15,6 +15,22 @@ final class ConcatTests: XCTestCase {
     XCTAssertEqual(82, concat(incr, incr, square, square) { $0 + 1 }(1))
   }
 
+  func testThrowingConcat() {
+    func incr(_ x: Int) -> Int {
+      return x + 1
+    }
+
+    func square(_ x: Int) -> Int {
+      return x * x
+    }
+
+    XCTAssertEqual(82, try concat(incr, nonThrowing(incr), square, square, incr)(1))
+    XCTAssertEqual(82, try concat(incr, incr, nonThrowing(square), square) { $0 + 1 }(1))
+    XCTAssertThrowsError(try concat(throwing(incr), incr, square, square, incr)(1))
+    XCTAssertThrowsError(try concat(incr, incr, square, throwing(square)) { $0 + 1 }(1))
+    XCTAssertThrowsError(try concat(incr, incr, square, square, and: throwing(incr))(1))
+  }
+
   func testInoutConcat() {
     func incr(_ x: inout Int) {
       x += 1
@@ -32,6 +48,48 @@ final class ConcatTests: XCTestCase {
     concat(incr, incr, square, square) { (y: inout Int) in y += 1 }(&x)
     XCTAssertEqual(82, x)
   }
+
+  func testThrowingInoutConcat() throws {
+    func incr(_ x: inout Int) {
+      x += 1
+    }
+
+    func square(_ x: inout Int) {
+      x *= x
+    }
+
+    var x = 1
+    try concat(incr, nonThrowing(incr), square, square, incr)(&x)
+    XCTAssertEqual(82, x)
+
+    x = 1
+    try concat(incr, incr, nonThrowing(square), square) { (y: inout Int) in y += 1 }(&x)
+    XCTAssertEqual(82, x)
+
+    x = 1
+    XCTAssertThrowsError(try concat(throwing(incr), incr, square, square, incr)(&x))
+
+    x = 1
+    XCTAssertThrowsError(try concat(incr, incr, square, throwing(square)) { (y: inout Int) in y += 1 }(&x))
+
+    x = 1
+    XCTAssertThrowsError(try concat(incr, incr, square, square, and: throwing(incr))(&x))
+  }
 }
 
+private struct ExpectedError: Error {}
+private func throwing<A, B>(_: (A) -> B) -> (A) throws -> B {
+    return { _ in throw ExpectedError() }
+}
 
+private func throwing<A>(_: (inout A) -> Void) -> (inout A) throws -> Void {
+    return { _ in throw ExpectedError() }
+}
+
+private func nonThrowing<A, B>(_ f: @escaping (A) -> B) -> (A) throws -> B {
+    return f
+}
+
+private func nonThrowing<A>(_ f: @escaping (inout A) -> Void) -> (inout A) throws -> Void {
+    return f
+}

--- a/Tests/OvertureTests/ConcatTests.swift
+++ b/Tests/OvertureTests/ConcatTests.swift
@@ -68,12 +68,15 @@ final class ConcatTests: XCTestCase {
 
     x = 1
     XCTAssertThrowsError(try concat(throwing(incr), incr, square, square, incr)(&x))
+    XCTAssertEqual(1, x)
 
     x = 1
     XCTAssertThrowsError(try concat(incr, incr, square, throwing(square)) { (y: inout Int) in y += 1 }(&x))
+    XCTAssertEqual(9, x)
 
     x = 1
     XCTAssertThrowsError(try concat(incr, incr, square, square, and: throwing(incr))(&x))
+    XCTAssertEqual(81, x)
   }
 }
 

--- a/Tests/OvertureTests/PipeTests.swift
+++ b/Tests/OvertureTests/PipeTests.swift
@@ -6,23 +6,57 @@ final class PipeTests: XCTestCase {
     XCTAssertEqual("2", pipe(incr, String.init)(1))
   }
 
+  func testThrowingPipe2() {
+    XCTAssertEqual("2", try pipe(nonThrowing(incr), String.init)(1))
+    XCTAssertThrowsError(try pipe(throwing(incr), String.init)(1))
+  }
+
   func testPipe3() {
     XCTAssertEqual("3", pipe(incr, incr, String.init)(1))
+  }
+
+  func testThrowingPipe3() {
+    XCTAssertEqual("3", try pipe(incr, nonThrowing(incr), String.init)(1))
+    XCTAssertThrowsError(try pipe(throwing(incr), incr, String.init)(1))
   }
 
   func testPipe4() {
     XCTAssertEqual("4", pipe(incr, incr, incr, String.init)(1))
   }
 
+  func testThrowingPipe4() {
+    XCTAssertEqual("4", try pipe(incr, incr, nonThrowing(incr), String.init)(1))
+    XCTAssertThrowsError(try pipe(incr, incr, throwing(incr), String.init)(1))
+  }
+
   func testPipe5() {
     XCTAssertEqual("5", pipe(incr, incr, incr, incr, String.init)(1))
+  }
+
+  func testThrowingPipe5() {
+    XCTAssertEqual("5", try pipe(incr, incr, incr, incr, nonThrowing(String.init))(1))
+    XCTAssertThrowsError(try pipe(incr, throwing(incr), incr, incr, String.init)(1))
   }
 
   func testPipe6() {
     XCTAssertEqual("6", pipe(incr, incr, incr, incr, incr, String.init)(1))
   }
+
+  func testThrowingPipe6() {
+    XCTAssertEqual("6", try pipe(incr, nonThrowing(incr), incr, incr, incr, String.init)(1))
+    XCTAssertThrowsError(try pipe(incr, incr, incr, incr, incr, throwing(String.init))(1))
+  }
 }
 
 private func incr(_ x: Int) -> Int {
   return x + 1
+}
+
+private struct ExpectedError: Error {}
+private func throwing<A, B>(_: (A) -> B) -> (A) throws -> B {
+    return { _ in throw ExpectedError() }
+}
+
+private func nonThrowing<A, B>(_ f: @escaping (A) -> B) -> (A) throws -> B {
+    return f
 }


### PR DESCRIPTION
Here is the implementation of throwing overloads as discussed in #9.

**What happens for `chain(nonThrowing, nonThrowing)`?**
It works as previously.

**What happens for `try chain(throwing, nonThrowing)`?**
It works as `nonThrowing` will be treated as throwing.

**What happens for `try chain(nonThrowing, nonThrowing)`?**
Use case: when refactoring your functions to not throw anymore.
```
Warning: no calls to throwing functions occur within 'try' expression

    XCTAssertEqual(.some(9), try chain(incr, square)(2))
                             ^
    at Tests/OvertureTests/ChainTests.swift:12
```

**What's missing:**
- [x] Restore test coverage