### PR TITLE
Prefer a direct link to swiftenv's install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 dist: trusty
 install:
   - if [ $TRAVIS_OS_NAME = linux ]; then
-      eval "$(curl -sL https://swiftenv.fuller.li/install.sh)";
+      eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)";
     fi
 script:
   - swift test


### PR DESCRIPTION
The shortened URL seems to have broken.