### PR TITLE
Add CURRENT_PROJECT_VERSION build setting

### DIFF
--- a/Overture.xcodeproj/project.pbxproj
+++ b/Overture.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 			baseConfigurationReference = OBJ_8 /* Development.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -403,6 +404,7 @@
 			baseConfigurationReference = OBJ_8 /* Development.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CURRENT_PROJECT_VERSION = 1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",


### PR DESCRIPTION
Fixes iTunesConect error when Overture is integrated into the project without using any dependency manager by simple drag&drop of Overture.xcodeproj.

Error: `ERROR ITMS-90056: "This bundle Payload/My.app/Frameworks/Overture.framework is invalid. The Info.plist file is missing the required key: CFBundleVersion."`