### PR TITLE
Bump podspec to 0.3.0

### DIFF
--- a/Overture.podspec
+++ b/Overture.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Overture"
-  s.version = "0.2.0"
+  s.version = "0.3.0"
   s.summary = "A library for function composition."
 
   s.description = <<-DESC


### PR DESCRIPTION
Looks like we forgot to do this in our 0.3.0 release. 

Does this mean we should go to 0.3.1?