### PR TITLE
Fix/missing zip with public declaration

### DIFF
--- a/Sources/Overture/ZipSequence.swift
+++ b/Sources/Overture/ZipSequence.swift
@@ -174,7 +174,7 @@ func zip<
     return { zip($0, $1, $2).map(f) }
 }
 
-func zip<
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,
@@ -187,7 +187,7 @@ func zip<
     return { zip($0, $1, $2, $3).map(f) }
 }
 
-func zip<
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,
@@ -201,7 +201,7 @@ func zip<
     return { zip($0, $1, $2, $3, $4).map(f) }
 }
 
-func zip<
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,
@@ -216,7 +216,7 @@ func zip<
     return { zip($0, $1, $2, $3, $4, $5).map(f) }
 }
 
-func zip<
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,
@@ -232,7 +232,7 @@ func zip<
     return { zip($0, $1, $2, $3, $4, $5, $6).map(f) }
 }
 
-func zip<
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,
@@ -249,7 +249,7 @@ func zip<
     return { zip($0, $1, $2, $3, $4, $5, $6, $7).map(f) }
 }
 
-func zip<
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,
@@ -267,7 +267,7 @@ func zip<
     return { zip($0, $1, $2, $3, $4, $5, $6, $7, $8).map(f) }
 }
 
-func zip<
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,

--- a/Sources/Overture/ZipSequence.swift
+++ b/Sources/Overture/ZipSequence.swift
@@ -162,7 +162,18 @@ public struct Zip3Sequence<
   }
 }
 
-func zip<
+public func zip<
+  A: Sequence,
+  B: Sequence,
+  C
+  >(
+  with f: @escaping (A.Element, B.Element) -> C
+  )
+  -> (A, B) -> [C] {
+    return { zip($0, $1).map(f) }
+}
+
+public func zip<
   A: Sequence,
   B: Sequence,
   C: Sequence,

--- a/Tests/OvertureTests/ZipTests.swift
+++ b/Tests/OvertureTests/ZipTests.swift
@@ -67,4 +67,454 @@ final class ZipTests: XCTestCase {
     XCTAssertEqual(18, snd.8)
     XCTAssertEqual(20, snd.9)
   }
+  
+  func testZip2WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int
+        ) {
+        self.a = a
+        self.b = b
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+  }
+  
+  func testZip3WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int
+        ) {
+        self.a = a
+        self.b = b
+        self.c = c
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+  }
+  
+  func testZip4WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      let d: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int,
+        _ d: Int
+        ) {
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    XCTAssertEqual(7, fst.d)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+    XCTAssertEqual(8, snd.d)
+  }
+  
+  func testZip5WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      let d: Int
+      let e: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int,
+        _ d: Int,
+        _ e: Int
+        ) {
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = e
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    XCTAssertEqual(7, fst.d)
+    XCTAssertEqual(9, fst.e)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+    XCTAssertEqual(8, snd.d)
+    XCTAssertEqual(10, snd.e)
+  }
+  
+  func testZip6WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      let d: Int
+      let e: Int
+      let f: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int,
+        _ d: Int,
+        _ e: Int,
+        _ f: Int
+        ) {
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = e
+        self.f = f
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10],
+      [11, 12]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    XCTAssertEqual(7, fst.d)
+    XCTAssertEqual(9, fst.e)
+    XCTAssertEqual(11, fst.f)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+    XCTAssertEqual(8, snd.d)
+    XCTAssertEqual(10, snd.e)
+    XCTAssertEqual(12, snd.f)
+  }
+  
+  func testZip7WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      let d: Int
+      let e: Int
+      let f: Int
+      let g: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int,
+        _ d: Int,
+        _ e: Int,
+        _ f: Int,
+        _ g: Int
+        ) {
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = e
+        self.f = f
+        self.g = g
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10],
+      [11, 12],
+      [13, 14]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    XCTAssertEqual(7, fst.d)
+    XCTAssertEqual(9, fst.e)
+    XCTAssertEqual(11, fst.f)
+    XCTAssertEqual(13, fst.g)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+    XCTAssertEqual(8, snd.d)
+    XCTAssertEqual(10, snd.e)
+    XCTAssertEqual(12, snd.f)
+    XCTAssertEqual(14, snd.g)
+  }
+  
+  func testZip8WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      let d: Int
+      let e: Int
+      let f: Int
+      let g: Int
+      let h: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int,
+        _ d: Int,
+        _ e: Int,
+        _ f: Int,
+        _ g: Int,
+        _ h: Int
+        ) {
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = e
+        self.f = f
+        self.g = g
+        self.h = h
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10],
+      [11, 12],
+      [13, 14],
+      [15, 16]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    XCTAssertEqual(7, fst.d)
+    XCTAssertEqual(9, fst.e)
+    XCTAssertEqual(11, fst.f)
+    XCTAssertEqual(13, fst.g)
+    XCTAssertEqual(15, fst.h)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+    XCTAssertEqual(8, snd.d)
+    XCTAssertEqual(10, snd.e)
+    XCTAssertEqual(12, snd.f)
+    XCTAssertEqual(14, snd.g)
+    XCTAssertEqual(16, snd.h)
+  }
+  
+  func testZip9WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      let d: Int
+      let e: Int
+      let f: Int
+      let g: Int
+      let h: Int
+      let i: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int,
+        _ d: Int,
+        _ e: Int,
+        _ f: Int,
+        _ g: Int,
+        _ h: Int,
+        _ i: Int
+        ) {
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = e
+        self.f = f
+        self.g = g
+        self.h = h
+        self.i = i
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10],
+      [11, 12],
+      [13, 14],
+      [15, 16],
+      [17, 18]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    XCTAssertEqual(7, fst.d)
+    XCTAssertEqual(9, fst.e)
+    XCTAssertEqual(11, fst.f)
+    XCTAssertEqual(13, fst.g)
+    XCTAssertEqual(15, fst.h)
+    XCTAssertEqual(17, fst.i)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+    XCTAssertEqual(8, snd.d)
+    XCTAssertEqual(10, snd.e)
+    XCTAssertEqual(12, snd.f)
+    XCTAssertEqual(14, snd.g)
+    XCTAssertEqual(16, snd.h)
+    XCTAssertEqual(18, snd.i)
+  }
+    
+  func testZip10WithSequence() {
+    struct ZipInit {
+      let a: Int
+      let b: Int
+      let c: Int
+      let d: Int
+      let e: Int
+      let f: Int
+      let g: Int
+      let h: Int
+      let i: Int
+      let j: Int
+      
+      init(
+        _ a: Int,
+        _ b: Int,
+        _ c: Int,
+        _ d: Int,
+        _ e: Int,
+        _ f: Int,
+        _ g: Int,
+        _ h: Int,
+        _ i: Int,
+        _ j: Int
+      ) {
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = e
+        self.f = f
+        self.g = g
+        self.h = h
+        self.i = i
+        self.j = j
+      }
+    }
+    let zipped = zip(with: ZipInit.init)(
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10],
+      [11, 12],
+      [13, 14],
+      [15, 16],
+      [17, 18],
+      [19, 20]
+    )
+    let array = Array(zipped)
+    let fst = array[0]
+    XCTAssertEqual(1, fst.a)
+    XCTAssertEqual(3, fst.b)
+    XCTAssertEqual(5, fst.c)
+    XCTAssertEqual(7, fst.d)
+    XCTAssertEqual(9, fst.e)
+    XCTAssertEqual(11, fst.f)
+    XCTAssertEqual(13, fst.g)
+    XCTAssertEqual(15, fst.h)
+    XCTAssertEqual(17, fst.i)
+    XCTAssertEqual(19, fst.j)
+    let snd = array[1]
+    XCTAssertEqual(2, snd.a)
+    XCTAssertEqual(4, snd.b)
+    XCTAssertEqual(6, snd.c)
+    XCTAssertEqual(8, snd.d)
+    XCTAssertEqual(10, snd.e)
+    XCTAssertEqual(12, snd.f)
+    XCTAssertEqual(14, snd.g)
+    XCTAssertEqual(16, snd.h)
+    XCTAssertEqual(18, snd.i)
+    XCTAssertEqual(20, snd.j)
+  }
 }


### PR DESCRIPTION
Fixes #25 

@stephencelis: here is the PR to fix my #25 issue. I've also added tests but I'm not sure if you'll approve all this boilerplate code. Maybe it would have been better to introduce some kind of code generation like sourcery for that but anyway, they are in place and passing.

I've also add `zip(with:)` for Zip2Sequence that is not in the standard lib.