### PR TITLE
Update Overture.podspec

### DIFF
--- a/Overture.podspec
+++ b/Overture.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "2.0"
-  s.swift_version = '5.0'
+  s.swift_version = '5.0', '5.1', '5.2', '5.3'
 
   s.source_files  = "Sources", "Sources/**/*.swift"
 end

--- a/Overture.podspec
+++ b/Overture.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "2.0"
+  s.swift_version = '5.0'
 
   s.source_files  = "Sources", "Sources/**/*.swift"
 end


### PR DESCRIPTION
When setting up Overture via Cocoapods, I am seeing the following error:

```
[!] Unable to determine Swift version for the following pods:

- `Overture` does not specify a Swift version and none of the targets (`MyTarget`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

This PR sets the Swift version on the podspec. 